### PR TITLE
Remove unnecessary call of cleanPoints(this->pointsCursor); 

### DIFF
--- a/FuzzyComposition.cpp
+++ b/FuzzyComposition.cpp
@@ -20,7 +20,6 @@ FuzzyComposition::FuzzyComposition(){
 
 // DESTRUTOR
 FuzzyComposition::~FuzzyComposition(){
-	this->cleanPoints(this->pointsCursor);
 	this->cleanPoints(this->points);
 }
 


### PR DESCRIPTION
Need to remove unnecessary call cleanPoints(this->point Cursor) in ~Fuzzy Composition destructor, because it causes illegal duplicate call of free(aux) on the last element of points.